### PR TITLE
Some minor improvements of the dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,21 +14,24 @@ updates:
     directory: "/webapp" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
+    ignore: # Ignore the non-LTS node versions (17/01/2024 >20)
       - dependency-name: "node"
-        versions: ["21.x"]
+        versions: ["21.x","22.x","23.x","24.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/webapp" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore: # Avoid puppeteer+jest version updates to avoid incompatibilities/problems in CI-CD
+      - dependency-name: "puppeteer*"
+      - dependency-name: "jest*"
   # Maintain the npm dependencies of the GatewayService
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/gatewayservice" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
+    ignore: # Ignore the non-LTS node versions (17/01/2024 >20)
       - dependency-name: "node"
-        versions: ["21.x"]
+        versions: ["21.x","22.x","23.x","24.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/gatewayservice" # Location of package manifests
     schedule:
@@ -38,9 +41,9 @@ updates:
     directory: "/users/authservice" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
+    ignore: # Ignore the non-LTS node versions (17/01/2024 >20)
       - dependency-name: "node"
-        versions: ["21.x"]
+        versions: ["21.x","22.x","23.x","24.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/users/authservice" # Location of package manifests
     schedule:
@@ -50,9 +53,9 @@ updates:
     directory: "/users/userservice" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
+    ignore: # Ignore the non-LTS node versions (17/01/2024 >20)
       - dependency-name: "node"
-        versions: ["21.x"]
+        versions: ["21.x","22.x","23.x","24.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/users/userservice" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     directory: "/webapp" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node"
+        versions: ["21.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/webapp" # Location of package manifests
     schedule:
@@ -23,6 +26,9 @@ updates:
     directory: "/gatewayservice" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node"
+        versions: ["21.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/gatewayservice" # Location of package manifests
     schedule:
@@ -32,6 +38,9 @@ updates:
     directory: "/users/authservice" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node"
+        versions: ["21.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/users/authservice" # Location of package manifests
     schedule:
@@ -41,6 +50,9 @@ updates:
     directory: "/users/userservice" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node"
+        versions: ["21.x"]
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/users/userservice" # Location of package manifests
     schedule:


### PR DESCRIPTION
Addressing how to ignore dependencies :
- Currently, the system disregards updates for non-LTS Node dependencies, a matter discussed in an open GitHub issue: https://github.com/dependabot/dependabot-core/issues/2247.
- Resolved dependency issues with Puppeteer and Jest to prevent complications in the CI/CD pipeline.